### PR TITLE
fix 3DLoMatch test trigger

### DIFF
--- a/Test_cycle.py
+++ b/Test_cycle.py
@@ -209,7 +209,7 @@ class cycle_tester():
     
     def run(self):
         self.run_onedatasets(self.datasets) 
-        if self.datasets['wholesetname'] is '3dmatch':
+        if self.datasets['wholesetname'] == '3dmatch':
             self.run_onedatasets_givengraph(self.datasetsLo)
 
             


### PR DESCRIPTION
Hi @HpWang-whu,
Thanks for open source the code. But there may be a small bug in `Test_cycle.py`
https://github.com/WHU-USI3DV/SGHR/blob/fdfb0811f1ca5e3df741b2ca8f9180c702c83c20/Test_cycle.py#L210-L213
Here `is` is used to trigger the 3DLoMatch test, however `is` checks for identity - if the two variables point to the exact same object. Since `self.datasets['wholesetname']` and `3dmatch` are different objects, the 3DLoMatch test will not executed. Simply use `==` to replace `is` will fix this issue.